### PR TITLE
Add testing for supported platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  test:
+    name: test
+    strategy:
+      matrix:
+        platform:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: npm install --loglevel verbose && bin/wasm-opt --version


### PR DESCRIPTION
I guess this is the easiest way of finding out if it works on all those platforms.

Actions need to be enabled for the repo for the workflow to show up.

It currently succeeds only on `macos`. For `linux` and `windows` it fails due to `libbinaryen.dylib` stuff.

You should be able to see the runs [here](https://github.com/cmichi/wasm-opt/pull/1). The runs for `windows` and `macos` were cancelled because the `linux` one failed [with this error](https://github.com/cmichi/wasm-opt/runs/2396679293?check_suite_focus=true#step:4:746):
```
Error: Error: ENOENT: no such file or directory, copyfile '/home/runner/work/wasm-opt/wasm-opt/binaryen-version_100/lib/libbinaryen.dylib' -> '/home/runner/work/wasm-opt/wasm-opt/lib/libbinaryen.dylib'
    at main (/home/runner/work/wasm-opt/wasm-opt/bin/index.js:104:11)
```